### PR TITLE
if error, output stack trace on new line

### DIFF
--- a/example-pino-http.js
+++ b/example-pino-http.js
@@ -14,6 +14,9 @@ var server = http.createServer(function (req, res) {
     res.end('ou weee here is some updated info')
     return
   } else if (req.url === '/content' && req.method === 'PUT') {
+  } else if (req.url === '/error') {
+    res.emit('error', new Error('oh no'))
+    res.end()
   } else {
     res.statusCode = 404
     res.end()

--- a/index.js
+++ b/index.js
@@ -67,7 +67,13 @@ function PinoColada () {
     if (contentLength != null) output.push(formatBundleSize(contentLength))
     if (responseTime != null) output.push(formatLoadTime(responseTime))
 
-    return output.filter(noEmpty).join(' ')
+    var str = output.filter(noEmpty).join(' ')
+
+    // if error, output stack trace on new line
+    var err = obj.err
+    if (err && err.stack) str += nl + err.stack
+
+    return str
   }
 
   function formatDate () {

--- a/index.js
+++ b/index.js
@@ -88,12 +88,16 @@ function PinoColada () {
   }
 
   function formatMessage (obj) {
-    if (obj.level === 'error') return chalk.dim.red(obj.message)
+    if (obj.level === 'error') return chalk.dim.red(formatError(obj))
     if (obj.level === 'trace') return chalk.dim.white(obj.message)
     if (obj.level === 'warn') return chalk.dim.magenta(obj.message)
     if (obj.level === 'debug') return chalk.dim.yellow(obj.message)
-    if (obj.level === 'fatal') return chalk.bgRed(obj.message) + nl + obj.stack
+    if (obj.level === 'fatal') return chalk.bgRed(formatError(obj))
     if (obj.level === 'info' || obj.level === 'userlvl') return formatMessageName(obj.message)
+  }
+
+  function formatError (obj) {
+    return obj.stack ? obj.message + nl + obj.stack : obj.message
   }
 
   function formatUrl (url) {

--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ function PinoColada () {
     if (contentLength != null) output.push(formatBundleSize(contentLength))
     if (responseTime != null) output.push(formatLoadTime(responseTime))
 
+    var err = obj.err
+    if (err) output.push(nl + chalk.dim.red(formatError(err)))
+
     return output.filter(noEmpty).join(' ')
   }
 

--- a/index.js
+++ b/index.js
@@ -67,13 +67,7 @@ function PinoColada () {
     if (contentLength != null) output.push(formatBundleSize(contentLength))
     if (responseTime != null) output.push(formatLoadTime(responseTime))
 
-    var str = output.filter(noEmpty).join(' ')
-
-    // if error, output stack trace on new line
-    var err = obj.err
-    if (err && err.stack) str += nl + err.stack
-
-    return str
+    return output.filter(noEmpty).join(' ')
   }
 
   function formatDate () {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hapi": "^16.1.0",
     "hapi-pino": "^1.3.0",
     "merry": "^4.3.1",
-    "pino-http": "^2.4.2",
+    "pino-http": "^2.6.0",
     "standard": "^8.6.0"
   },
   "dependencies": {


### PR DESCRIPTION
hey,

this pull request adds special treatment for errors: if there is an error and it has a stack trace, then output the stack trace on a new line.

i'm not sure if this is a good idea or a terrible idea, but i wanted to see my stack traces so here we are. how do you log errors?

also, if this is an okay change, happy for feedback on the code since it seems awkward. :cat:

cheers!