### PR TITLE
pino-debug support

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,9 +45,11 @@ function PinoColada () {
 
     if (!obj.level) obj.level = 'userlvl'
     if (!obj.name) obj.name = ''
+    if (!obj.ns) obj.ns = ''
 
     output.push(formatDate())
     output.push(formatLevel(obj.level))
+    output.push(formatNs(obj.ns))
     output.push(formatName(obj.name))
     output.push(formatMessage(obj))
 
@@ -81,6 +83,10 @@ function PinoColada () {
 
   function formatLevel (level) {
     return emojiLog[level] + ' '
+  }
+
+  function formatNs (name) {
+    return chalk.cyan(name)
   }
 
   function formatName (name) {


### PR DESCRIPTION
this adds support for pino-debug - which adds an `ns` property to each object

This is different to `name` (I think) - `ns` reflects the debug namespace, whereas `name` is being used for naming a particular log message - it's a fine distinction, but distinct nonetheless

It changes output from 
<img width="1440" alt="screen shot 2017-04-12 at 16 17 17" src="https://cloud.githubusercontent.com/assets/1190716/24966439/d7ccd9e4-1f9e-11e7-82eb-10334722bbbe.png">

to

<img width="1440" alt="screen shot 2017-04-12 at 16 37 00" src="https://cloud.githubusercontent.com/assets/1190716/24966446/dab06266-1f9e-11e7-91fe-7c022843f6cd.png">


Also works in white

<img width="1440" alt="screen shot 2017-04-12 at 16 36 45" src="https://cloud.githubusercontent.com/assets/1190716/24966456/dfb5fba4-1f9e-11e7-9fd0-b36aee0ef001.png">


cc @mcollina

