### PR TITLE
fix formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,12 +88,13 @@ function PinoColada () {
   }
 
   function formatMessage (obj) {
-    if (obj.level === 'error') return chalk.dim.red(obj.message)
-    if (obj.level === 'trace') return chalk.dim.white(obj.message)
-    if (obj.level === 'warn') return chalk.dim.magenta(obj.message)
-    if (obj.level === 'debug') return chalk.dim.yellow(obj.message)
-    if (obj.level === 'fatal') return chalk.bgRed(obj.message) + nl + obj.stack
-    if (obj.level === 'info' || obj.level === 'userlvl') return formatMessageName(obj.message)
+    var msg = formatMessageName(obj.message)
+    if (obj.level === 'error') return chalk.dim.red(msg)
+    if (obj.level === 'trace') return chalk.dim.white(msg)
+    if (obj.level === 'warn') return chalk.dim.magenta(msg)
+    if (obj.level === 'debug') return chalk.dim.yellow(msg)
+    if (obj.level === 'fatal') return chalk.bgRed(msg) + nl + obj.stack
+    if (obj.level === 'info' || obj.level === 'userlvl') return chalk.green.dim(msg)
   }
 
   function formatUrl (url) {
@@ -111,7 +112,7 @@ function PinoColada () {
 
   function formatLoadTime (elapsedTime) {
     var elapsed = parseInt(elapsedTime, 10)
-    var time = time > 9999 ? prettyMs(elapsed) : elapsed + 'ms'
+    var time = prettyMs(elapsed)
     return chalk.gray(time)
   }
 
@@ -122,9 +123,9 @@ function PinoColada () {
   }
 
   function formatMessageName (message) {
-    if (message === 'request') return chalk.dim.green('<--')
-    if (message === 'response') return chalk.dim.green('-->')
-    return chalk.dim.green(message)
+    if (message === 'request') return '<--'
+    if (message === 'response') return '-->'
+    return message
   }
 
   function noEmpty (val) {


### PR DESCRIPTION
- if non-info log levels were used, http requests started showing up weird
- time was always displayed as `ms` even if it was multiple seconds, now always uses the time formatter

### before

<img width="497" alt="screen shot 2017-04-13 at 13 05 32" src="https://cloud.githubusercontent.com/assets/2467194/25002293/ed4e4d9c-2049-11e7-9e03-303e9d917e0c.png">

### after

<img width="500" alt="screen shot 2017-04-13 at 13 05 37" src="https://cloud.githubusercontent.com/assets/2467194/25002329/18cd1a2a-204a-11e7-9a8a-a2d952ff76e8.png">


