### PR TITLE
Expose formatter

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -1,0 +1,124 @@
+var prettyBytes = require('prettier-bytes')
+var prettyMs = require('pretty-ms')
+var padLeft = require('pad-left')
+var chalk = require('chalk')
+var nl = '\n'
+
+var emojiLog = {
+  warn: '⚠️',
+  info: '✨',
+  error: '🚨',
+  debug: '🐛',
+  fatal: '💀',
+  trace: '🔍'
+}
+
+module.exports = function createFormatter () {
+  return function formatter (obj) {
+    var output = []
+
+    if (!obj.message) obj.message = obj.msg
+    if (typeof obj.level === 'number') obj.level = convertLogNumber(obj.level)
+    if (!obj.level) obj.level = 'userlvl'
+    if (!obj.name) obj.name = ''
+    if (!obj.ns) obj.ns = ''
+
+    output.push(formatDate())
+    output.push(formatLevel(obj.level))
+    output.push(formatNs(obj.ns))
+    output.push(formatName(obj.name))
+    output.push(formatMessage(obj))
+
+    var req = obj.req
+    var res = obj.res
+    var statusCode = (res) ? res.statusCode : obj.statusCode
+    var responseTime = obj.responseTime || obj.elapsed
+    var method = (req) ? req.method : obj.method
+    var contentLength = obj.contentLength
+    var url = (req) ? req.url : obj.url
+
+    if (method != null) {
+      output.push(formatMethod(method))
+      output.push(formatStatusCode(statusCode))
+    }
+    if (url != null) output.push(formatUrl(url))
+    if (contentLength != null) output.push(formatBundleSize(contentLength))
+    if (responseTime != null) output.push(formatLoadTime(responseTime))
+
+    return output.filter(noEmpty).join(' ')
+  }
+
+  function convertLogNumber (level) {
+    if (level === 20) return 'debug'
+    if (level === 30) return 'info'
+    if (level === 40) return 'warn'
+    if (level === 50) return 'error'
+    if (level === 60) return 'fatal'
+  }
+
+  function formatDate () {
+    var date = new Date()
+    var hours = padLeft(date.getHours().toString(), 2, '0')
+    var minutes = padLeft(date.getMinutes().toString(), 2, '0')
+    var seconds = padLeft(date.getSeconds().toString(), 2, '0')
+    var prettyDate = hours + ':' + minutes + ':' + seconds
+    return chalk.gray(prettyDate)
+  }
+
+  function formatLevel (level) {
+    return emojiLog[level] + ' '
+  }
+
+  function formatNs (name) {
+    return chalk.cyan(name)
+  }
+
+  function formatName (name) {
+    return chalk.blue(name)
+  }
+
+  function formatMessage (obj) {
+    var msg = formatMessageName(obj.message)
+    if (obj.level === 'error') return chalk.dim.red(msg)
+    if (obj.level === 'trace') return chalk.dim.white(msg)
+    if (obj.level === 'warn') return chalk.dim.magenta(msg)
+    if (obj.level === 'debug') return chalk.dim.yellow(msg)
+    if (obj.level === 'fatal') return chalk.bgRed(msg) + nl + obj.stack
+    if (obj.level === 'info' || obj.level === 'userlvl') return chalk.green.dim(msg)
+  }
+
+  function formatUrl (url) {
+    return chalk.white(url)
+  }
+
+  function formatMethod (method) {
+    return chalk.white(method)
+  }
+
+  function formatStatusCode (statusCode) {
+    statusCode = statusCode || 'xxx'
+    return chalk.white(statusCode)
+  }
+
+  function formatLoadTime (elapsedTime) {
+    var elapsed = parseInt(elapsedTime, 10)
+    var time = prettyMs(elapsed)
+    return chalk.gray(time)
+  }
+
+  function formatBundleSize (bundle) {
+    var bytes = parseInt(bundle, 10)
+    var size = prettyBytes(bytes).replace(/ /, '')
+    return chalk.gray(size)
+  }
+
+  function formatMessageName (message) {
+    if (message === 'request') return '<--'
+    if (message === 'response') return '-->'
+    return message
+  }
+
+  function noEmpty (val) {
+    return !!val
+  }
+}

--- a/index.js
+++ b/index.js
@@ -23,26 +23,14 @@ function PinoColada () {
   function parse (line) {
     var obj = jsonParse(line)
     if (!obj.value || obj.err) return line + nl
-    obj = obj.value
-
-    if (!obj.level) return line + nl
-    if (typeof obj.level === 'number') convertLogNumber(obj)
-
-    return output(obj) + nl
+    return formatter(obj.value) + nl
   }
 
-  function convertLogNumber (obj) {
-    if (!obj.message) obj.message = obj.msg
-    if (obj.level === 20) obj.level = 'debug'
-    if (obj.level === 30) obj.level = 'info'
-    if (obj.level === 40) obj.level = 'warn'
-    if (obj.level === 50) obj.level = 'error'
-    if (obj.level === 60) obj.level = 'fatal'
-  }
-
-  function output (obj) {
+  function formatter (obj) {
     var output = []
 
+    if (!obj.message) obj.message = obj.msg
+    if (typeof obj.level === 'number') obj.level = convertLogNumber(obj.level)
     if (!obj.level) obj.level = 'userlvl'
     if (!obj.name) obj.name = ''
     if (!obj.ns) obj.ns = ''
@@ -70,6 +58,14 @@ function PinoColada () {
     if (responseTime != null) output.push(formatLoadTime(responseTime))
 
     return output.filter(noEmpty).join(' ')
+  }
+
+  function convertLogNumber (level) {
+    if (level === 20) return 'debug'
+    if (level === 30) return 'info'
+    if (level === 40) return 'warn'
+    if (level === 50) return 'error'
+    if (level === 60) return 'fatal'
   }
 
   function formatDate () {

--- a/index.js
+++ b/index.js
@@ -1,136 +1,18 @@
-var prettyBytes = require('prettier-bytes')
-var jsonParse = require('fast-json-parse')
-var prettyMs = require('pretty-ms')
-var padLeft = require('pad-left')
 var split = require('split2')
-var chalk = require('chalk')
+var jsonParse = require('fast-json-parse')
+var createFormatter = require('./formatter')
 var nl = '\n'
-
-var emojiLog = {
-  warn: '⚠️',
-  info: '✨',
-  error: '🚨',
-  debug: '🐛',
-  fatal: '💀',
-  trace: '🔍'
-}
 
 module.exports = PinoColada
 
 function PinoColada () {
+  var formatter = createFormatter()
+
   return split(parse)
 
   function parse (line) {
     var obj = jsonParse(line)
     if (!obj.value || obj.err) return line + nl
     return formatter(obj.value) + nl
-  }
-
-  function formatter (obj) {
-    var output = []
-
-    if (!obj.message) obj.message = obj.msg
-    if (typeof obj.level === 'number') obj.level = convertLogNumber(obj.level)
-    if (!obj.level) obj.level = 'userlvl'
-    if (!obj.name) obj.name = ''
-    if (!obj.ns) obj.ns = ''
-
-    output.push(formatDate())
-    output.push(formatLevel(obj.level))
-    output.push(formatNs(obj.ns))
-    output.push(formatName(obj.name))
-    output.push(formatMessage(obj))
-
-    var req = obj.req
-    var res = obj.res
-    var statusCode = (res) ? res.statusCode : obj.statusCode
-    var responseTime = obj.responseTime || obj.elapsed
-    var method = (req) ? req.method : obj.method
-    var contentLength = obj.contentLength
-    var url = (req) ? req.url : obj.url
-
-    if (method != null) {
-      output.push(formatMethod(method))
-      output.push(formatStatusCode(statusCode))
-    }
-    if (url != null) output.push(formatUrl(url))
-    if (contentLength != null) output.push(formatBundleSize(contentLength))
-    if (responseTime != null) output.push(formatLoadTime(responseTime))
-
-    return output.filter(noEmpty).join(' ')
-  }
-
-  function convertLogNumber (level) {
-    if (level === 20) return 'debug'
-    if (level === 30) return 'info'
-    if (level === 40) return 'warn'
-    if (level === 50) return 'error'
-    if (level === 60) return 'fatal'
-  }
-
-  function formatDate () {
-    var date = new Date()
-    var hours = padLeft(date.getHours().toString(), 2, '0')
-    var minutes = padLeft(date.getMinutes().toString(), 2, '0')
-    var seconds = padLeft(date.getSeconds().toString(), 2, '0')
-    var prettyDate = hours + ':' + minutes + ':' + seconds
-    return chalk.gray(prettyDate)
-  }
-
-  function formatLevel (level) {
-    return emojiLog[level] + ' '
-  }
-
-  function formatNs (name) {
-    return chalk.cyan(name)
-  }
-
-  function formatName (name) {
-    return chalk.blue(name)
-  }
-
-  function formatMessage (obj) {
-    var msg = formatMessageName(obj.message)
-    if (obj.level === 'error') return chalk.dim.red(msg)
-    if (obj.level === 'trace') return chalk.dim.white(msg)
-    if (obj.level === 'warn') return chalk.dim.magenta(msg)
-    if (obj.level === 'debug') return chalk.dim.yellow(msg)
-    if (obj.level === 'fatal') return chalk.bgRed(msg) + nl + obj.stack
-    if (obj.level === 'info' || obj.level === 'userlvl') return chalk.green.dim(msg)
-  }
-
-  function formatUrl (url) {
-    return chalk.white(url)
-  }
-
-  function formatMethod (method) {
-    return chalk.white(method)
-  }
-
-  function formatStatusCode (statusCode) {
-    statusCode = statusCode || 'xxx'
-    return chalk.white(statusCode)
-  }
-
-  function formatLoadTime (elapsedTime) {
-    var elapsed = parseInt(elapsedTime, 10)
-    var time = prettyMs(elapsed)
-    return chalk.gray(time)
-  }
-
-  function formatBundleSize (bundle) {
-    var bytes = parseInt(bundle, 10)
-    var size = prettyBytes(bytes).replace(/ /, '')
-    return chalk.gray(size)
-  }
-
-  function formatMessageName (message) {
-    if (message === 'request') return '<--'
-    if (message === 'response') return '-->'
-    return message
-  }
-
-  function noEmpty (val) {
-    return !!val
   }
 }


### PR DESCRIPTION
That way you can use it as pino formatter:
```js
pino({
  prettyPrint: {
    formatter: require('pino-colada/formatter')()
  }
})
```

With the current module I had to do a workaround:
```js
  const stream = require('pino-colada')()
  stream.pipe(process.stdout)
  return pino(opts, stream)
```