### PR TITLE
chore: bump chalk version to pick up output control via FORCE_COLOR env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "standard": "^8.6.0"
   },
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^2.0.1",
     "fast-json-parse": "^1.0.2",
     "pad-left": "^2.1.0",
     "pad-right": "^0.2.2",


### PR DESCRIPTION
[`chalk@1.1.3`](https://github.com/chalk/chalk/tree/1.1.3), the latest version of chalk satisfying the [semver spec on `master`](https://github.com/lrlna/pino-colada/blob/fbaa7b8/package.json#L32), is locked into major version `2` of [`supports-color`](http://npm.im/supports-color), which is 12 releases and 2 major versions behind `latest`:
```
❯ npm view chalk@1.1.3 --json | jq '.dependencies["supports-color"]'
"^2.0.0"

❯ npm view supports-color --json | jq .versions
[
  "0.2.0",
  "1.0.0",
  "1.1.0",
  "1.2.0",
  "1.2.1",
  "1.3.0",
  "1.3.1",
  "2.0.0",
  "3.0.0",
  "3.0.1",
  "3.1.0",
  "3.1.1",
  "3.1.2",
  "3.2.0",
  "3.2.1",
  "3.2.2",
  "3.2.3",
  "4.0.0",
  "4.1.0",
  "4.2.0"
]
```

We should bump to major version 2 of chalk which will bring in `supports-color@^4` and provide a slew of patches and a few important features, including the ability to control color output via environment variable: https://github.com/chalk/supports-color/releases/tag/v4.0.0