### PR TITLE
fix aligned emoji for Unicode 9 wide characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ var emojiLog = {
   trace: '🔍'
 }
 
+function isWideEmoji (character) {
+  return character !== '⚠️'
+}
+
 module.exports = PinoColada
 
 function PinoColada () {
@@ -83,7 +87,9 @@ function PinoColada () {
   }
 
   function formatLevel (level) {
-    return emojiLog[level] + ' '
+    const emoji = emojiLog[level]
+    const padding = isWideEmoji(emoji) ? '' : ' '
+    return emoji + padding
   }
 
   function formatNs (name) {


### PR DESCRIPTION
On MacOS High Sierra, in the default Terminal app, the character width of emoji varies according to Unicode 9. Some are 1 character wide, others 2 wide. This patch adds/withholds padding accordingly.

#### Before

<img width="270" alt="screen shot 2018-01-28 at 6 06 43 am" src="https://user-images.githubusercontent.com/78718/35476811-73d7a7f6-03f1-11e8-96b1-4901470cb18a.png">

#### After

<img width="264" alt="screen shot 2018-01-28 at 6 05 39 am" src="https://user-images.githubusercontent.com/78718/35476813-7b8f32de-03f1-11e8-8f2a-4b0e309c577f.png">
