### PR TITLE
fatal level tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,12 @@ function PinoColada () {
     if (obj.level === 'trace') return chalk.dim.white(msg)
     if (obj.level === 'warn') return chalk.dim.magenta(msg)
     if (obj.level === 'debug') return chalk.dim.yellow(msg)
-    if (obj.level === 'fatal') return chalk.bgRed(msg) + nl + obj.stack
+    if (obj.level === 'fatal') {
+      var pretty = chalk.white.bgRed(msg)
+      return obj.stack
+        ? pretty + nl + obj.stack
+        : pretty
+    }
     if (obj.level === 'info' || obj.level === 'userlvl') return chalk.green.dim(msg)
   }
 


### PR DESCRIPTION
- support fatal level without stack property
- force foreground to white

#### Before

<img width="308" alt="screen shot 2018-01-28 at 6 25 41 am" src="https://user-images.githubusercontent.com/78718/35476941-40c45fa0-03f4-11e8-8f14-03a2eaa209fe.png">

#### After

<img width="307" alt="screen shot 2018-01-28 at 6 26 03 am" src="https://user-images.githubusercontent.com/78718/35476945-467fedec-03f4-11e8-90fa-139f210f6bb8.png">
