### PR TITLE
fix: msg property not logged if log level isn't a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,13 @@ function PinoColada () {
     obj = obj.value
 
     if (!obj.level) return line + nl
+    if (!obj.message) obj.message = obj.msg
     if (typeof obj.level === 'number') convertLogNumber(obj)
 
     return output(obj) + nl
   }
 
   function convertLogNumber (obj) {
-    if (!obj.message) obj.message = obj.msg
     if (obj.level === 10) obj.level = 'trace'
     if (obj.level === 20) obj.level = 'debug'
     if (obj.level === 30) obj.level = 'info'


### PR DESCRIPTION
Hi!

Using pino-colada all my log messages are printed as `undefined` because I've got pino set with `useLevelLabels` to true and pino-colada only prints the `msg` property if the log level is a number. 

I've moved the line which copies `msg` to `message` out of the number conversion function to solve this.

Thanks!