### PR TITLE
Always append error stack

### DIFF
--- a/example-pino-http.js
+++ b/example-pino-http.js
@@ -6,13 +6,10 @@ var server = http.createServer(function (req, res) {
 
   if (req.url === '/') {
     res.end('hello world')
-    return
   } else if (req.url === '/user' && req.method === 'POST') {
     res.end('new user ✨')
-    return
   } else if (req.url === '/content' && req.method === 'PUT') {
     res.end('ou weee here is some updated info')
-    return
   } else if (req.url === '/content' && req.method === 'PUT') {
   } else {
     res.statusCode = 404

--- a/example.js
+++ b/example.js
@@ -6,23 +6,23 @@ var error = merry.error
 var app = merry()
 
 app.router([
-  [ '/', function (req, res, ctx, done) {
+  ['/', function (req, res, ctx, done) {
     done(null, 'hello world')
   }],
-  [ '/user', {
+  ['/user', {
     post: function (req, res, ctx, done) {
       done(null, 'new user ✨')
     }
   }],
-  [ '/content', {
+  ['/content', {
     put: function (req, res, ctx, done) {
       done(null, 'ou weee here is some updated info')
     }
   }],
-  [ '/error', function (req, res, ctx, done) {
+  ['/error', function (req, res, ctx, done) {
     done(error({ statusCode: 500, message: 'helloooo server error' }))
   }],
-  [ '/404', notFound() ]
+  ['/404', notFound()]
 ])
 
 var server = http.createServer(app.start())

--- a/index.js
+++ b/index.js
@@ -102,17 +102,16 @@ function PinoColada () {
 
   function formatMessage (obj) {
     var msg = formatMessageName(obj.message)
-    if (obj.level === 'error') return chalk.red(msg)
-    if (obj.level === 'trace') return chalk.white(msg)
-    if (obj.level === 'warn') return chalk.magenta(msg)
-    if (obj.level === 'debug') return chalk.yellow(msg)
-    if (obj.level === 'info' || obj.level === 'userlvl') return chalk.green(msg)
-    if (obj.level === 'fatal') {
-      var pretty = chalk.white.bgRed(msg)
-      return obj.stack
+    var pretty;
+    if (obj.level === 'error') pretty = chalk.red(msg)
+    if (obj.level === 'trace') pretty = chalk.white(msg)
+    if (obj.level === 'warn') pretty =  chalk.magenta(msg)
+    if (obj.level === 'debug') pretty =  chalk.yellow(msg)
+    if (obj.level === 'info' || obj.level === 'userlvl') pretty = chalk.green(msg)
+    if (obj.level === 'fatal') pretty = chalk.white.bgRed(msg)
+    return obj.stack
         ? pretty + nl + obj.stack
         : pretty
-    }
   }
 
   function formatUrl (url) {

--- a/index.js
+++ b/index.js
@@ -102,16 +102,16 @@ function PinoColada () {
 
   function formatMessage (obj) {
     var msg = formatMessageName(obj.message)
-    var pretty;
+    var pretty
     if (obj.level === 'error') pretty = chalk.red(msg)
     if (obj.level === 'trace') pretty = chalk.white(msg)
-    if (obj.level === 'warn') pretty =  chalk.magenta(msg)
-    if (obj.level === 'debug') pretty =  chalk.yellow(msg)
+    if (obj.level === 'warn') pretty = chalk.magenta(msg)
+    if (obj.level === 'debug') pretty = chalk.yellow(msg)
     if (obj.level === 'info' || obj.level === 'userlvl') pretty = chalk.green(msg)
     if (obj.level === 'fatal') pretty = chalk.white.bgRed(msg)
     return obj.stack
-        ? pretty + nl + obj.stack
-        : pretty
+      ? pretty + nl + obj.stack
+      : pretty
   }
 
   function formatUrl (url) {

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function PinoColada () {
     if (obj.level === 'debug') pretty = chalk.yellow(msg)
     if (obj.level === 'info' || obj.level === 'userlvl') pretty = chalk.green(msg)
     if (obj.level === 'fatal') pretty = chalk.white.bgRed(msg)
-    return obj.stack
+    return (obj.level === 'fatal' || obj.level === 'error') && obj.stack
       ? pretty + nl + obj.stack
       : pretty
   }


### PR DESCRIPTION
When using pino-colada, I found errors logged at the `error` level don't output stacktrace. Apparently pino-colada only output stacktrace at the `fatal` level. This PR changed it to output stacktrace on any level if the object contains a `stack` property.