### PR TITLE
Use ISO format

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var prettyBytes = require('prettier-bytes')
 var jsonParse = require('fast-json-parse')
 var prettyMs = require('pretty-ms')
-var padLeft = require('pad-left')
 var split = require('split2')
 var chalk = require('chalk')
 var nl = '\n'

--- a/index.js
+++ b/index.js
@@ -79,10 +79,7 @@ function PinoColada () {
 
   function formatDate () {
     var date = new Date()
-    var hours = padLeft(date.getHours().toString(), 2, '0')
-    var minutes = padLeft(date.getMinutes().toString(), 2, '0')
-    var seconds = padLeft(date.getSeconds().toString(), 2, '0')
-    var prettyDate = hours + ':' + minutes + ':' + seconds
+    var prettyDate = date.toISOString()
     return chalk.gray(prettyDate)
   }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "fast-json-parse": "^1.0.2",
-    "pad-left": "^2.1.0",
     "pad-right": "^0.2.2",
     "prettier-bytes": "^1.0.3",
     "pretty-ms": "^2.1.0",


### PR DESCRIPTION
The current "date" format does not include the actual date, which makes the logs a lot less useful. The current implementation also does not include a timezone identifier which can complicate debugging international deployments. Consider this format, which is universally meaningful (and still just as pretty!).