### PR TITLE
check obj.err for stack, see fastify/fastify-cli#214

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,9 @@ function PinoColada () {
     var method = (req) ? req.method : obj.method
     var contentLength = obj.contentLength
     var url = (req) ? req.url : obj.url
+    var stack = (obj.level === 'fatal' || obj.level === 'error')
+      ? obj.stack || (obj.err && obj.err.stack)
+      : null
 
     if (method != null) {
       output.push(formatMethod(method))
@@ -73,6 +76,7 @@ function PinoColada () {
     if (url != null) output.push(formatUrl(url))
     if (contentLength != null) output.push(formatBundleSize(contentLength))
     if (responseTime != null) output.push(formatLoadTime(responseTime))
+    if (stack != null) output.push(formatStack(stack))
 
     return output.filter(noEmpty).join(' ')
   }
@@ -109,9 +113,7 @@ function PinoColada () {
     if (obj.level === 'debug') pretty = chalk.yellow(msg)
     if (obj.level === 'info' || obj.level === 'userlvl') pretty = chalk.green(msg)
     if (obj.level === 'fatal') pretty = chalk.white.bgRed(msg)
-    return (obj.level === 'fatal' || obj.level === 'error') && obj.stack
-      ? pretty + nl + obj.stack
-      : pretty
+    return pretty
   }
 
   function formatUrl (url) {
@@ -143,6 +145,10 @@ function PinoColada () {
     if (message === 'request') return '<--'
     if (message === 'response') return '-->'
     return message
+  }
+
+  function formatStack (stack) {
+    return stack ? nl + stack : ''
   }
 
   function noEmpty (val) {


### PR DESCRIPTION
Add support for `obj.err.stack` as discussed in https://github.com/fastify/fastify-cli/issues/214.
I moved checking stack from `formatMessage()` to `output()` function - it allows to show stack on next line after url and other request details:

![image](https://user-images.githubusercontent.com/1473072/72064063-286b1b00-32ec-11ea-88b7-f06e4136cad9.png)
