### PR TITLE
Updated dependencies, drop old node support (8+ now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
-  - 6
-  - 7
+  - 8
+  - 10
+  - 12

--- a/example-hapi-pino.js
+++ b/example-hapi-pino.js
@@ -1,34 +1,29 @@
 'use strict'
 
-var Hapi = require('hapi')
+const Hapi = require('@hapi/hapi')
 
-// Create a server with a host and port
-var server = new Hapi.Server()
-server.connection({
-  host: 'localhost',
-  port: 8080
-})
+async function run () {
+  // Create a server with a host and port
+  const server = Hapi.Server({
+    port: 3000,
+    host: 'localhost'
+  })
 
-// Add the route
-server.route({
-  method: 'GET',
-  path: '/',
-  handler: function (request, reply) {
-    return reply('hello world')
-  }
-})
+  await server.register(require('hapi-pino'))
 
-server.register(require('hapi-pino'), function (err) {
-  if (err) {
-    console.error(err)
-    process.exit(1)
-  }
-
-  // Start the server
-  server.start(function (err) {
-    if (err) {
-      console.error(err)
-      process.exit(1)
+  // Add the route
+  server.route({
+    method: 'GET',
+    path: '/',
+    handler: function (request, reply) {
+      return 'hello world'
     }
   })
+
+  await server.start()
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
 })

--- a/package.json
+++ b/package.json
@@ -22,19 +22,19 @@
     "pretty-printer"
   ],
   "devDependencies": {
-    "hapi": "^16.1.0",
-    "hapi-pino": "^1.3.0",
-    "merry": "^4.3.1",
-    "pino-http": "^2.4.2",
-    "standard": "^8.6.0"
+    "@hapi/hapi": "^18.0.0",
+    "hapi-pino": "^6.3.0",
+    "merry": "^4.0.0",
+    "pino-http": "^4.3.0",
+    "standard": "^14.0.0"
   },
   "dependencies": {
-    "chalk": "^2.0.1",
+    "chalk": "^3.0.0",
     "fast-json-parse": "^1.0.2",
     "pad-left": "^2.1.0",
     "pad-right": "^0.2.2",
     "prettier-bytes": "^1.0.3",
-    "pretty-ms": "^2.1.0",
-    "split2": "^2.1.1"
+    "pretty-ms": "^5.0.0",
+    "split2": "^3.0.0"
   }
 }


### PR DESCRIPTION
chokidar@2 depends on a vulnerable dependency as defined in https://app.snyk.io/org/mcollina/project/77093841-f46e-47c6-ae49-548b8c809106?utm_campaign=weekly_report&utm_source=Project&fromGitHubAuth=true.

In the process of updating chokidar, I've updated most of the dependencies (minus Merry, as it does not log by default anymore) because I thought it was handy.

This change in semver-major as the minimum version of Node.js needed by chokidar is 8.