### PR TITLE
pino v6 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function isObject (input) {
 }
 
 function isPinoLog (log) {
-  return log && (log.hasOwnProperty('v') && log.v === 1)
+  return log && (log.hasOwnProperty('level'))
 }
 
 module.exports = PinoColada


### PR DESCRIPTION
Pino 6 does not have a `v` property, so the next best thing we have is `level` 