### PR TITLE
Output `err` attribute in case there is not an error stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.vscode
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -85,8 +85,8 @@ function PinoColada () {
       ? obj.stack || (obj.err && obj.err.stack)
       : null
     // Output err if it has more keys than 'stack'
-    var err = (obj.level === 'fatal' || obj.level === 'error')
-      && obj.err && Object.keys(obj.err).find(key => key !== 'stack')
+    var err = (obj.level === 'fatal' || obj.level === 'error') &&
+      obj.err && Object.keys(obj.err).find(key => key !== 'stack')
       ? obj.err
       : null
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function isObject (input) {
 }
 
 function isPinoLog (log) {
-  return log && (log.hasOwnProperty('level'))
+  return log && (Object.prototype.hasOwnProperty.call(log, 'level'))
 }
 
 module.exports = PinoColada
@@ -84,6 +84,10 @@ function PinoColada () {
     var stack = (obj.level === 'fatal' || obj.level === 'error')
       ? obj.stack || (obj.err && obj.err.stack)
       : null
+    // Do not output err if already outputting error stack
+    var err = (obj.level === 'fatal' || obj.level === 'error') && obj.err && !stack
+      ? obj.err
+      : null
 
     if (method != null) {
       output.push(formatMethod(method))
@@ -93,6 +97,7 @@ function PinoColada () {
     if (contentLength != null) output.push(formatBundleSize(contentLength))
     if (responseTime != null) output.push(formatLoadTime(responseTime))
     if (stack != null) output.push(formatStack(stack))
+    if (err != null) output.push(formatErrorProp(err))
 
     return output.filter(noEmpty).join(' ')
   }
@@ -165,6 +170,10 @@ function PinoColada () {
 
   function formatStack (stack) {
     return stack ? nl + stack : ''
+  }
+
+  function formatErrorProp (errorPropValue) {
+    return nl + JSON.stringify({ err: errorPropValue }, null, 2)
   }
 
   function noEmpty (val) {

--- a/index.js
+++ b/index.js
@@ -84,8 +84,9 @@ function PinoColada () {
     var stack = (obj.level === 'fatal' || obj.level === 'error')
       ? obj.stack || (obj.err && obj.err.stack)
       : null
-    // Do not output err if already outputting error stack
-    var err = (obj.level === 'fatal' || obj.level === 'error') && obj.err && !stack
+    // Output err if it has more keys than 'stack'
+    var err = (obj.level === 'fatal' || obj.level === 'error')
+      && obj.err && Object.keys(obj.err).find(key => key !== 'stack')
       ? obj.err
       : null
 


### PR DESCRIPTION
We have some use cases that errors are not Node exceptions but other errors such as axios errors. They are also serialized in the `err` key by a custom serializer, but the details are not printed in pino-colada now.

pino-pretty added an `errorLikeObjectKeys` option to support this case. So I think it'd be nice to have pino-colada to support the default case (when key is `err`).

A sample log message:

```
{
    "level": 50,
    "time": 1596945016648,
    "pid": 76949,
    "name": "Ingester",
    "err": {
        "responseData": {
            "errors": [
                {
                    "msg": "Invalid value",
                    "param": "group",
                    "location": "body"
                }
            ]
        },
        "responseStatus": 422
    }
}
```