### PR TITLE
always use LF as line ending, fixes #43

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# always use LF even on Windows
+* text=auto eol=lf


### PR DESCRIPTION
The published version 2.2.0 uses CRLF line endings in the `pino-colada` shell script. Shell scripts must use LF to work on *nix systems. This fixes issue #43.

The issue occurs only when used with yarn. npm automatically fixes the line endings for all shell scripts in `node_modules/.bin`.
For reference see: https://github.com/yarnpkg/yarn/issues/5480

Before publishing a new version, please make sure the file `bin.js` contains LF line endings.